### PR TITLE
Fikser GraphQL error ["string" has no subfields]

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,21 +37,6 @@ module.exports = {
       options: { prefixes: ["/app/*"] },
     },
     "gatsby-plugin-react-helmet",
-    {
-      // keep as first gatsby-source-filesystem plugin for gatsby image support
-      resolve: "gatsby-source-filesystem",
-      options: {
-        name: "images",
-        path: `${__dirname}/static/img/upload`,
-      },
-    },
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
-        path: `${__dirname}/src/pages`,
-        name: "pages",
-      },
-    },
     "gatsby-plugin-sharp",
     "gatsby-transformer-sharp",
     {
@@ -79,6 +64,22 @@ module.exports = {
         ],
       },
     },
+    {
+      // keep as first gatsby-source-filesystem plugin for gatsby image support
+      resolve: "gatsby-source-filesystem",
+      options: {
+        name: "images",
+        path: `${__dirname}/static/img/upload`,
+      },
+    },
+    {
+      resolve: "gatsby-source-filesystem",
+      options: {
+        path: `${__dirname}/src/pages`,
+        name: "pages",
+      },
+    },
+
     {
       resolve: "gatsby-plugin-styled-components",
     },


### PR DESCRIPTION
### Tester
Jeg gikk gjennom listen med mulige årsaker på problemet og testet dem. Jeg endrer rekkefølgen på pluginsene slik innlegget https://stackoverflow.com/q/55736780 foreslo. De andre failcasene hadde vi ikke.
- [x]  check spelling
- [x] check you have the right plugins (period)
- [x] check plugin order
- [x] use graphiql to see if you're getting a string for the images vs. an actual node (you can use transformers on a node but not a string)
- [ ] delete .cache and node modules and reinstall (denne må evt. gjøres på serversiden)

Mest sannsynlig var det rekkefølgen som skapte problemet, men hvis denne pull requesten ikke fungerer må jeg grave litt dypere..:)
