### PR TITLE
Midlertidig bytte av roverlaget til Ørn

### DIFF
--- a/src/data/calendars.json
+++ b/src/data/calendars.json
@@ -51,12 +51,11 @@
     "sortKey": 20
   },
   {
-    "name": "Roverne",
-    "nameExt": " (16-25 år)",
+    "name": "Ørn",
     "id": "nadderud.no_609bou5r8u9cl5e5lqdve7vq18@group.calendar.google.com",
-    "slug": "rover",
+    "slug": "troppen/ørn",
     "visible": true,
-    "sortKey": 30
+    "sortKey": 20
   },
   {
     "name": "Alle",


### PR DESCRIPTION
Slik som det er nå, har vi flere undergrupper en hva vi har kalender API's for. Vi mangler 1 kalender.

Ørn trenger sin egen. Ettersom Roverlaget ikke har lagt ut noe program, og heller ikke har noen store planer for det, byttes de midlertidig ut med ørn. 